### PR TITLE
feat: migrate to repository-based renovate presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Qlik OSS configurations for [renovate](https://renovatebot.com/).
 
-Documentataion for all options: https://renovatebot.com/docs/configuration-options/
+Documentation for all options: https://renovatebot.com/docs/configuration-options/
 
 ## Usage
 
@@ -10,6 +10,39 @@ Use repository-based presets:
 
 - `github>qlik-oss/renovate-config`
 - `github>qlik-oss/renovate-config:groupMinorPatch`
+
+## Exposed presets
+
+### `github>qlik-oss/renovate-config`
+
+Base Qlik OSS preset.
+
+- Extends common Renovate defaults and scheduling preferences
+- Adds monorepo grouping rules via:
+  - `picassoMono`
+  - `nebulaMono`
+  - `awMono`
+  - `groupMinorPatch`
+
+### `github>qlik-oss/renovate-config:picassoMono`
+
+Groups `picasso.js` ecosystem dependencies into one PR group (`picasso.js packages`).
+
+### `github>qlik-oss/renovate-config:nebulaMono`
+
+Groups `nebula.js` ecosystem dependencies into one PR group (`nebula.js packages`).
+
+### `github>qlik-oss/renovate-config:awMono`
+
+Groups `after-work.js` ecosystem dependencies into one PR group (`@after-work.js packages`).
+
+### `github>qlik-oss/renovate-config:groupMinorPatch`
+
+Groups `minor`/`patch`/`pin` updates into one PR group (`minor and patch`) and enables automerge for that group.
+
+## Matching strategy
+
+Monorepo presets use `matchSourceUrls` as primary matching with `matchPackageNames` fallback to keep grouping reliable when source metadata is missing.
 
 ## Rules
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Qlik OSS configurations for [renovate](https://renovatebot.com/).
 
 Documentataion for all options: https://renovatebot.com/docs/configuration-options/
 
+## Usage
+
+Use repository-based presets:
+
+- `github>qlik-oss/renovate-config`
+- `github>qlik-oss/renovate-config:groupMinorPatch`
+
 ## Rules
 
 Most of the rules are defaults defined here: https://github.com/renovatebot/presets/tree/master/packages/renovate-config-default

--- a/awMono.json
+++ b/awMono.json
@@ -1,0 +1,9 @@
+{
+  "description": "after-work.js monorepo packages",
+  "packageRules": [
+    {
+      "groupName": "@after-work.js packages",
+      "packagePatterns": ["^@after-work"]
+    }
+  ]
+}

--- a/awMono.json
+++ b/awMono.json
@@ -3,7 +3,14 @@
   "packageRules": [
     {
       "groupName": "@after-work.js packages",
-      "packagePatterns": ["^@after-work"]
+      "matchSourceUrls": [
+        "https://github.com/qlik-oss/after-work.js",
+        "https://github.com/qlik-oss/after-work.js/**"
+      ]
+    },
+    {
+      "groupName": "@after-work.js packages",
+      "matchPackageNames": ["@after-work/**"]
     }
   ]
 }

--- a/default.json
+++ b/default.json
@@ -1,0 +1,25 @@
+{
+  "description": "Qlik OSS base Renovate preset",
+  "extends": [
+    "schedule:weekends",
+    ":separateMajorReleases",
+    ":combinePatchMinorReleases",
+    ":ignoreUnstable",
+    ":prImmediately",
+    ":renovatePrefix",
+    ":semanticPrefixFixDepsChoreOthers",
+    ":updateNotScheduled",
+    ":automergeMinor",
+    ":ignoreModulesAndTests",
+    ":maintainLockFilesDisabled",
+    ":autodetectPinVersions",
+    ":prConcurrentLimit20",
+    "group:monorepos",
+    "github>qlik-oss/renovate-config:picassoMono",
+    "github>qlik-oss/renovate-config:nebulaMono",
+    "github>qlik-oss/renovate-config:awMono",
+    "github>qlik-oss/renovate-config:groupMinorPatch"
+  ],
+  "rebaseStalePrs": true,
+  "labels": ["renovate"]
+}

--- a/default.json
+++ b/default.json
@@ -11,7 +11,7 @@
     ":updateNotScheduled",
     ":automergeMinor",
     ":ignoreModulesAndTests",
-    ":maintainLockFilesDisabled",
+    ":maintainLockFilesWeekly",
     ":autodetectPinVersions",
     ":prConcurrentLimit20",
     "group:monorepos",

--- a/groupMinorPatch.json
+++ b/groupMinorPatch.json
@@ -1,0 +1,11 @@
+{
+  "description": "Group minor and patch updates for all packages in one",
+  "packageRules": [
+    {
+      "groupName": "minor and patch",
+      "packagePatterns": ["*"],
+      "updateTypes": ["minor", "patch", "pin"],
+      "automerge": true
+    }
+  ]
+}

--- a/nebulaMono.json
+++ b/nebulaMono.json
@@ -3,7 +3,14 @@
   "packageRules": [
     {
       "groupName": "nebula.js packages",
-      "packageNames": [
+      "matchSourceUrls": [
+        "https://github.com/qlik-oss/nebula.js",
+        "https://github.com/qlik-oss/nebula.js/**"
+      ]
+    },
+    {
+      "groupName": "nebula.js packages",
+      "matchPackageNames": [
         "@nebula.js/cli",
         "@nebula.js/cli-build",
         "@nebula.js/cli-sense",

--- a/nebulaMono.json
+++ b/nebulaMono.json
@@ -1,0 +1,15 @@
+{
+  "description": "nebula.js monorepo packages",
+  "packageRules": [
+    {
+      "groupName": "nebula.js packages",
+      "packageNames": [
+        "@nebula.js/cli",
+        "@nebula.js/cli-build",
+        "@nebula.js/cli-sense",
+        "@nebula.js/cli-serve",
+        "@nebula.js/stardust"
+      ]
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     },
     "picassoMono": {
       "description": "picasso.js monorepo packages",
-      "packagesRules": [{
+      "packageRules": [{
         "groupName": "picasso.js packages",
         "packageNames": [
           "picasso.js",
@@ -59,7 +59,7 @@
     },
     "nebulaMono": {
       "description": "nebula.js monorepo packages",
-      "packagesRules": [{
+      "packageRules": [{
         "groupName": "nebula.js packages",
         "packageNames": [
           "@nebula.js/cli",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         ":updateNotScheduled",
         ":automergeMinor",
         ":ignoreModulesAndTests",
-        ":maintainLockFilesDisabled",
+        ":maintainLockFilesWeekly",
         ":autodetectPinVersions",
         ":prConcurrentLimit20",
         "group:monorepos",
@@ -41,43 +41,59 @@
     },
     "awMono": {
       "description": "after-work.js monorepo packages",
-      "packageRules": [{
-        "groupName": "@after-work.js packages",
-        "packagePatterns": ["^@after-work"]
-      }]
+      "packageRules": [
+        {
+          "groupName": "@after-work.js packages",
+          "packagePatterns": [
+            "^@after-work"
+          ]
+        }
+      ]
     },
     "picassoMono": {
       "description": "picasso.js monorepo packages",
-      "packageRules": [{
-        "groupName": "picasso.js packages",
-        "packageNames": [
-          "picasso.js",
-          "picasso-plugin-hammer",
-          "picasso-plugin-q"
-        ]
-      }]
+      "packageRules": [
+        {
+          "groupName": "picasso.js packages",
+          "packageNames": [
+            "picasso.js",
+            "picasso-plugin-hammer",
+            "picasso-plugin-q"
+          ]
+        }
+      ]
     },
     "nebulaMono": {
       "description": "nebula.js monorepo packages",
-      "packageRules": [{
-        "groupName": "nebula.js packages",
-        "packageNames": [
-          "@nebula.js/cli",
-          "@nebula.js/cli-build",
-          "@nebula.js/cli-sense",
-          "@nebula.js/cli-serve",
-          "@nebula.js/stardust"
-        ]
-      }]
+      "packageRules": [
+        {
+          "groupName": "nebula.js packages",
+          "packageNames": [
+            "@nebula.js/cli",
+            "@nebula.js/cli-build",
+            "@nebula.js/cli-sense",
+            "@nebula.js/cli-serve",
+            "@nebula.js/stardust"
+          ]
+        }
+      ]
     },
     "groupMinorPatch": {
       "description": "Group minor and patch updates for all packages in one",
-      "packageRules": [{
-        "groupName": "minor and patch",
-        "packagePatterns": ["*"],
-        "updateTypes": ["minor", "patch", "pin"],
-        "automerge": true
-      }]
+      "packageRules": [
+        {
+          "groupName": "minor and patch",
+          "packagePatterns": [
+            "*"
+          ],
+          "updateTypes": [
+            "minor",
+            "patch",
+            "pin"
+          ],
+          "automerge": true
+        }
+      ]
     }
   }
 }

--- a/picassoMono.json
+++ b/picassoMono.json
@@ -1,0 +1,9 @@
+{
+  "description": "picasso.js monorepo packages",
+  "packageRules": [
+    {
+      "groupName": "picasso.js packages",
+      "packageNames": ["picasso.js", "picasso-plugin-hammer", "picasso-plugin-q"]
+    }
+  ]
+}

--- a/picassoMono.json
+++ b/picassoMono.json
@@ -3,7 +3,18 @@
   "packageRules": [
     {
       "groupName": "picasso.js packages",
-      "packageNames": ["picasso.js", "picasso-plugin-hammer", "picasso-plugin-q"]
+      "matchSourceUrls": [
+        "https://github.com/qlik-oss/picasso.js",
+        "https://github.com/qlik-oss/picasso.js/**"
+      ]
+    },
+    {
+      "groupName": "picasso.js packages",
+      "matchPackageNames": [
+        "picasso.js",
+        "picasso-plugin-hammer",
+        "picasso-plugin-q"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "qlik-oss",
-    "qlik-oss:groupMinorPatch"
+    "github>qlik-oss/renovate-config",
+    "github>qlik-oss/renovate-config:groupMinorPatch"
   ]
 }


### PR DESCRIPTION
## Summary
- migrate shared config to repository-based presets (default.json + named sub-presets)
- update self-usage in renovate.json to github>qlik-oss/renovate-config syntax
- fix packageRules key usage in legacy npm-hosted compatibility config
- add and document exposed presets in README.md
- improve monorepo grouping by using matchSourceUrls with matchPackageNames fallback

## Why
Renovate deprecated npm-hosted presets. This switches qlik-oss shared config to repository-hosted presets and keeps grouping behavior robust.

## Notes
- keeps compatibility while moving consumers to repository-hosted preset references
- follow-up consumer PR in qlik-oss/picasso.js switches extends to repository preset