### PR TITLE
chore: remove :automergeMinor from shared preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -8,7 +8,6 @@
     ":ignoreUnstable",
     ":renovatePrefix",
     ":updateNotScheduled",
-    ":automergeMinor",
     ":maintainLockFilesWeekly",
     ":autodetectPinVersions",
     ":prConcurrentLimit20",


### PR DESCRIPTION
Remove `:automergeMinor` from the shared preset. Individual repos and org presets will manage automerge configuration explicitly.